### PR TITLE
Overwrite setting for flare catalog file

### DIFF
--- a/stella/download_nn_set.py
+++ b/stella/download_nn_set.py
@@ -25,7 +25,7 @@ class DownloadSets(object):
              The path to where the catalog and light
              curve files are stored.
         flare_catalog_name : str, optional
-             What the flare catalog will be saved as. Default 
+             What the flare catalog will be saved as. Default
              is 'Guenther_2020_flare_catalog.txt'.
 
         Attributes
@@ -37,7 +37,7 @@ class DownloadSets(object):
             self.fn_dir = fn_dir
         else:
             self.fn_dir = os.path.join(os.path.expanduser('~'), '.stella')
-        
+
         if os.path.isdir(self.fn_dir) == False:
             os.mkdir(self.fn_dir)
 
@@ -69,26 +69,26 @@ class DownloadSets(object):
         self.flare_table = catalogs[1]
         self.flare_table.rename_column('_tab2_5', 'tpeak')
         self.flare_table.write(os.path.join(self.fn_dir, self.flare_catalog_name),
-                          format='csv')
+                          format='csv', overwrite=True)
         return
 
 
     def download_lightcurves(self, remove_fits=True):
         """
         Downloads light curves for the training, validation, and
-        test sets. 
+        test sets.
 
         Parameters
         ----------
         remove_fits : bool, optional
-             Allows the user to remove the TESS light curveFITS 
+             Allows the user to remove the TESS light curveFITS
              files when done. This will save space. Default is True.
         """
         if self.flare_table is None:
             self.flare_table = Table.read(os.path.join(self.fn_dir,
-                                                       self.flare_catalog_name), 
+                                                       self.flare_catalog_name),
                                           format='ascii')
-            
+
 
         tics = np.unique(self.flare_table['TIC'])
         npy_name = '{0:09d}_sector{1:02d}.npy'
@@ -107,20 +107,20 @@ class DownloadSets(object):
                 for j in range(len(lcs)):
                     # Default lightkurve flux = pdcsap_flux
                     lc = lcs[j].normalize()
-                    
+
                     np.save(os.path.join(self.fn_dir, npy_name.format(tics[i], lc.sector)),
-                            np.array([lc.time.value, 
-                                      lc.flux.value, 
+                            np.array([lc.time.value,
+                                      lc.flux.value,
                                       lc.flux_err.value]))
-                    
+
                     # Removes FITS files when done
                     if remove_fits == True:
                         for dp, dn, fn in os.walk(os.path.join(self.fn_dir, 'mastDownload')):
                             for file in [f for f in fn if f.endswith('.fits')]:
                                 os.remove(os.path.join(dp, file))
                                 os.rmdir(dp)
-                
-                
+
+
         if remove_fits == True:
             os.rmdir(os.path.join(self.fn_dir, 'mastDownload/TESS'))
             os.rmdir(os.path.join(self.fn_dir, 'mastDownload'))
@@ -147,20 +147,20 @@ class DownloadSets(object):
         hlsp_path = 'http://archive.stsci.edu/hlsps/stella/hlsp_stella_tess_ensemblemodel_all_tess_v0.1.0_bundle.tar.gz'
 
         new_path = os.path.join(self.fn_dir, 'models')
-        
+
         if os.path.isdir(new_path) == False:
             os.mkdir(new_path)
 
         if len(os.listdir(new_path)) == 100:
             print('Models have already been downloaded to ~/.stella/models')
-        
+
         else:
             os.system('cd {0} && curl -O -L {1}'.format(self.fn_dir, hlsp_path))
             tarball = [os.path.join(self.fn_dir, i) for i in os.listdir(self.fn_dir) if i.endswith('tar.gz')][0]
             os.system('cd {0} && tar -xzvf {1}'.format(self.fn_dir, tarball))
-            
+
             os.system('cd {0} && mv *.h5 {1}'.format(self.fn_dir, new_path))
-        
+
 
         self.model_dir = new_path
         models = np.sort([os.path.join(new_path, i) for i in os.listdir(new_path)])


### PR DESCRIPTION
Hello! This PR is to suggest adding an "overwrite=True" setting to the flare catalog download (in case the catalog already exists and, e.g., you want to try out downloading subsets of the flare table). Other changes to download_nn_set.py are just removing spaces. 