### PR TITLE
Switched from sklearn to scikit-learn in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ tornado
 matplotlib
 lightkurve>=2.0.0
 numpy
-sklearn
+scikit-learn
 more-itertools
 scipy!=1.4.1
 poetry


### PR DESCRIPTION
Sklearn has been deprecated.   Switching package name to scikit-learn is all that is required for fixing.