### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ tornado
 matplotlib
 lightkurve>=2.0.0
 numpy
-sklearn
+scikit-learn
 more-itertools
 scipy!=1.4.1
 poetry


### PR DESCRIPTION
sklearn no longer resolves to scikit-learn on pip and returns an error - calling it scikit-learn allows for a correct pip install